### PR TITLE
Added a few small (and unrelated) files:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+downloads
+gen

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,182 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+$(shell mkdir -p downloads)
+DOWNLOAD_RESULT := $(shell ./arm_gcc_download.sh downloads)
+ifneq ($(DOWNLOAD_RESULT), SUCCESS)
+  $(error Something went wrong with the GCC download: $(DOWNLOAD_RESULT))
+endif
+
+TOOLCHAIN_ROOT := downloads/gcc_embedded/
+TOOLCHAIN_PREFIX := $(TOOLCHAIN_ROOT)/bin/arm-none-eabi-
+CXX := $(TOOLCHAIN_PREFIX)g++
+CC := $(TOOLCHAIN_PREFIX)gcc
+AR := $(TOOLCHAIN_PREFIX)ar
+ARFLAGS := -r
+
+GENDIR := gen
+OBJDIR := $(GENDIR)/obj
+BINDIR := $(GENDIR)/bin
+
+LIBTFLM := $(GENDIR)/libtflm.a
+
+APOLLO3_SDK := third_party/AmbiqSuite-Rel2.2.0
+
+EXTRA_LIBS := \
+  $(APOLLO3_SDK)/boards_sfe/edge/bsp/gcc/bin/libam_bsp.a \
+  $(APOLLO3_SDK)/mcu/apollo3/hal/gcc/bin/libam_hal.a \
+  $(TOOLCHAIN_ROOT)/lib/gcc/arm-none-eabi/10.2.1/thumb/v7e-m+fp/hard/crtbegin.o \
+  -lm
+
+# The startup_gcc.c file is an altered version of the examples/hello_world/gcc/startup_gcc.c
+# file from Ambiq:
+#   - Increase the stack size from 1k to 20k
+#   - Change the application entry call from main() to _main()
+# The am_*.c files should be copied from the Ambiq Apollo3 SDK
+# _main.c contains application and target specific initialization, like
+# setting clock speed, default uart setups, etc. and an implementation
+# of the DebugLog interfaces.
+
+CMSIS_DSP_DIR := third_party/cmsis/CMSIS/DSP/Source
+
+THIRD_PARTY_CC_SRCS := \
+  $(APOLLO3_SDK)/boards/apollo3_evb/examples/hello_world/gcc_patched/startup_gcc.c \
+  $(APOLLO3_SDK)/utils/am_util_delay.c \
+  $(APOLLO3_SDK)/utils/am_util_faultisr.c \
+  $(APOLLO3_SDK)/utils/am_util_id.c \
+  $(APOLLO3_SDK)/utils/am_util_stdio.c \
+  $(APOLLO3_SDK)/devices/am_devices_led.c \
+  $(CMSIS_DSP_DIR)/BasicMathFunctions/arm_dot_prod_q15.c \
+  $(CMSIS_DSP_DIR)/BasicMathFunctions/arm_mult_q15.c \
+  $(CMSIS_DSP_DIR)/TransformFunctions/arm_rfft_init_q15.c \
+  $(CMSIS_DSP_DIR)/TransformFunctions/arm_rfft_q15.c \
+  $(CMSIS_DSP_DIR)/TransformFunctions/arm_bitreversal2.c \
+  $(CMSIS_DSP_DIR)/TransformFunctions/arm_cfft_q15.c \
+  $(CMSIS_DSP_DIR)/TransformFunctions/arm_cfft_radix4_q15.c \
+  $(CMSIS_DSP_DIR)/CommonTables/arm_const_structs.c \
+  $(CMSIS_DSP_DIR)/CommonTables/arm_common_tables.c \
+  $(CMSIS_DSP_DIR)/StatisticsFunctions/arm_mean_q15.c \
+  $(CMSIS_DSP_DIR)/StatisticsFunctions/arm_max_q7.c
+
+COMMON_FLAGS = \
+  -DPART_apollo3 \
+  -DAM_PACKAGE_BGA \
+  -DAM_PART_APOLLO3 \
+  -DGEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK \
+	-DCMSIS_NN \
+  -DTF_LITE_STATIC_MEMORY \
+  -DNDEBUG \
+  -DTF_LITE_MCU_DEBUG_LOG \
+  -D __FPU_PRESENT=1 \
+  -DARM_MATH_CM4 \
+  -fmessage-length=0 \
+  -fno-unwind-tables \
+  -ffunction-sections \
+  -fdata-sections \
+  -funsigned-char \
+  -MMD \
+  -mcpu=cortex-m4 \
+  -mthumb \
+  -mfpu=fpv4-sp-d16 \
+  -mfloat-abi=hard \
+  -Wvla \
+  -Wall \
+  -Wextra \
+  -Wno-missing-field-initializers \
+  -Wno-strict-aliasing \
+  -Wno-type-limits \
+  -Wno-unused-function \
+  -Wno-unused-parameter \
+  -fno-delete-null-pointer-checks \
+  -fomit-frame-pointer \
+  -nostdlib \
+  -ggdb \
+  -O3
+
+CXXFLAGS := \
+  -std=c++11 \
+  -fno-rtti \
+  -fno-use-cxa-atexit \
+  -fno-threadsafe-statics \
+  -fno-exceptions \
+  $(COMMON_FLAGS)
+
+CCFLAGS := \
+	-std=c11 \
+  $(COMMON_FLAGS)
+
+LDFLAGS += \
+  -mthumb -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard \
+  -nostartfiles -static \
+  -Wl,--gc-sections -Wl,--entry,Reset_Handler \
+  -Wl,--start-group -lm -lc -lgcc -Wl,--end-group \
+  -fno-exceptions \
+  -nostdlib --specs=nano.specs -t -lstdc++ -lc -lnosys -lm \
+  -Wl,-T,$(APOLLO3_SDK)/boards/apollo3_evb/examples/hello_world/gcc_patched/apollo3evb.ld \
+  -Wl,-Map=gen/sparkfun_edge.map,--cref
+
+INCLUDES := \
+  -I. \
+  -I./third_party/gemmlowp \
+  -I./third_party/flatbuffers/include \
+  -I./third_party/ruy \
+  -I./third_party/cmsis/CMSIS/Core/Include/ \
+  -I./third_party/cmsis/CMSIS/DSP/Include/ \
+  -I$(TOOLCHAIN_ROOT)/arm-none-eabi/ \
+  -I$(APOLLO3_SDK)/mcu/apollo3/ \
+  -I$(APOLLO3_SDK)/mcu/apollo3/regs \
+  -I$(APOLLO3_SDK)/mcu/apollo3/hal \
+  -I$(APOLLO3_SDK)/CMSIS/ARM/Include/ \
+  -I$(APOLLO3_SDK)/CMSIS/AmbiqMicro/Include/ \
+  -I$(APOLLO3_SDK)/boards_sfe/edge/bsp \
+  -I$(APOLLO3_SDK)/boards_sfe/common/third_party/hm01b0 \
+  -I$(APOLLO3_SDK)/devices/ \
+  -I$(APOLLO3_SDK)/utils/ \
+  -Ithird_party/cmsis/CMSIS/NN/Include/ \
+  -Ithird_party/cmsis/
+
+TFLM_CC_SRCS := $(shell find tensorflow -name "*.cc" -o -name "*.c")
+CMSIS_NN_SRCS := $(shell find third_party/cmsis/CMSIS/NN/Source -name "*.cc" -o -name "*.c")
+
+ALL_SRCS := \
+	$(CMSIS_NN_SRCS) \
+	$(TFLM_CC_SRCS) \
+  $(THIRD_PARTY_CC_SRCS) \
+	system_setup.cc
+
+OBJS := $(addprefix $(OBJDIR)/, $(patsubst %.c,%.o,$(patsubst %.cc,%.o,$(ALL_SRCS))))
+
+$(OBJDIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+$(OBJDIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CCFLAGS) $(INCLUDES) -c $< -o $@
+
+$(LIBTFLM): $(OBJS)
+	@mkdir -p $(dir $@)
+	$(AR) $(ARFLAGS) $(LIBTFLM) $(OBJS)
+
+clean:
+	rm -rf $(GENDIR)
+
+libtflm: $(LIBTFLM)
+
+hello_world: libtflm
+	@mkdir -p $(BINDIR)
+	$(CXX) $(CXXFLAGS) $(wildcard examples/hello_world/*.cc) $(INCLUDES) $(LIBTFLM) $(LDFLAGS) $(EXTRA_LIBS) -o $(BINDIR)/$@
+
+examples: hello_world

--- a/arm_gcc_download.sh
+++ b/arm_gcc_download.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Called with following arguments:
+# 1 - Path to the downloads folder which is typically
+#     tensorflow/lite/micro/tools/make/downloads
+#
+# This script is called from the Makefile and uses the following convention to
+# enable determination of sucess/failure:
+#
+#   - If the script is successful, the only output on stdout should be SUCCESS.
+#     The makefile checks for this particular string.
+#
+#   - Any string on stdout that is not SUCCESS will be shown in the makefile as
+#     the cause for the script to have failed.
+#
+#   - Any other informational prints should be on stderr.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR=${SCRIPT_DIR}
+cd "${ROOT_DIR}"
+
+DOWNLOADS_DIR=${1}
+if [ ! -d ${DOWNLOADS_DIR} ]; then
+  echo "The top-level downloads directory: ${DOWNLOADS_DIR} does not exist."
+  exit 1
+fi
+
+DOWNLOADED_GCC_PATH=${DOWNLOADS_DIR}/gcc_embedded
+
+if [ -d ${DOWNLOADED_GCC_PATH} ]; then
+  echo >&2 "${DOWNLOADED_GCC_PATH} already exists, skipping the download."
+else
+
+  GCC_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2"
+
+  TEMPFILE=$(mktemp -d)/temp_file
+  wget ${GCC_URL} -O ${TEMPFILE} >&2
+
+  mkdir ${DOWNLOADED_GCC_PATH}
+  tar -C ${DOWNLOADED_GCC_PATH} --strip-components=1 -xjf ${TEMPFILE} >&2
+  echo >&2 "Unpacked to directory: ${DOWNLOADED_GCC_PATH}"
+fi
+
+echo "SUCCESS"

--- a/system_setup.cc
+++ b/system_setup.cc
@@ -1,0 +1,98 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/lite/micro/system_setup.h"
+
+#include "tensorflow/lite/micro/debug_log.h"
+#include "tensorflow/lite/micro/cortex_m_generic/debug_log_callback.h"
+#include "tensorflow/lite/micro/micro_time.h"
+
+// These are headers from Ambiq's Apollo3 SDK.
+#include "am_bsp.h"         // NOLINT
+#include "am_mcu_apollo.h"  // NOLINT
+#include "am_util.h"        // NOLINT
+
+namespace {
+
+// Select CTIMER 1 as benchmarking timer on Sparkfun Edge. This timer must not
+// be used elsewhere.
+constexpr int kTimerNum = 1;
+
+// Clock set to operate at 12MHz.
+constexpr int kClocksPerSecond = 12e6;
+
+// Enables 96MHz burst mode on Sparkfun Edge. Enable in timer since most
+// benchmarks and profilers want maximum performance for debugging.
+void BurstModeEnable() {
+  am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX, 0);
+
+  // Set the default cache configuration
+  am_hal_cachectrl_config(&am_hal_cachectrl_defaults);
+  am_hal_cachectrl_enable();
+
+  am_hal_burst_avail_e eBurstModeAvailable;
+  am_hal_burst_mode_e eBurstMode;
+
+  // Check that the Burst Feature is available.
+  int status = am_hal_burst_mode_initialize(&eBurstModeAvailable);
+  if (status != AM_HAL_STATUS_SUCCESS ||
+      eBurstModeAvailable != AM_HAL_BURST_AVAIL) {
+    DebugLog("Failed to initialize burst mode.\n");
+    return;
+  }
+
+  status = am_hal_burst_mode_enable(&eBurstMode);
+
+  if (status != AM_HAL_STATUS_SUCCESS || eBurstMode != AM_HAL_BURST_MODE) {
+    DebugLog("Failed to Enable Burst Mode operation\n");
+  }
+}
+
+void TflmDebugLog(const char* s) {
+  am_util_stdio_printf("%s", s);
+}
+
+
+}  // namespace
+
+namespace tflite {
+
+// Calling this method enables a timer that runs for eternity. The user is
+// responsible for avoiding trampling on this timer's config, otherwise timing
+// measurements may no longer be valid.
+void InitializeTarget() {
+  am_bsp_uart_printf_enable();
+
+  RegisterDebugLogCallback(TflmDebugLog);
+
+  BurstModeEnable();
+  am_hal_ctimer_config_t timer_config;
+  // Operate as a 32-bit timer.
+  timer_config.ui32Link = 1;
+  // Set timer A to continuous mode at 12MHz.
+  timer_config.ui32TimerAConfig =
+      AM_HAL_CTIMER_FN_CONTINUOUS | AM_HAL_CTIMER_HFRC_12MHZ;
+
+  am_hal_ctimer_stop(kTimerNum, AM_HAL_CTIMER_BOTH);
+  am_hal_ctimer_clear(kTimerNum, AM_HAL_CTIMER_BOTH);
+  am_hal_ctimer_config(kTimerNum, &timer_config);
+  am_hal_ctimer_start(kTimerNum, AM_HAL_CTIMER_TIMERA);
+}
+
+int32_t ticks_per_second() { return kClocksPerSecond; }
+
+int32_t GetCurrentTimeTicks() { return CTIMERn(kTimerNum)->TMR0; }
+
+}  // namespace tflite


### PR DESCRIPTION
 * download script to get arm-gcc as part of the make command.

 * gitignore to ignore the downloads and gen directories

 * Makefile which should be very close to something that can be used to
   build hello_world. There are some additional CMSIS headers and
   sources that need to be copied over (will be added in a separate PR).

 * sparkfun_edge-specific implementation of system_setup.cc

With this change, we are close to being able to build the hello_world example. Note that the code in examples/hello_world is still a direct copy of upstream tensorflow. The specialization for sparkfun edge will be added later.
